### PR TITLE
remove internal schema column

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,3 +1,7 @@
 pub mod error;
 
 pub use error::*;
+
+pub const INTERNAL_METADATA_COLUMN: &str = "_streaming_internal_metadata";
+
+// use denormalized::common::INTERNAL_METADATA_COLUMN;

--- a/crates/core/src/datasource/kafka/kafka_config.rs
+++ b/crates/core/src/datasource/kafka/kafka_config.rs
@@ -6,6 +6,7 @@ use apache_avro::Schema as AvroSchema;
 use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef, TimeUnit};
 
 use datafusion::logical_expr::SortExpr;
+use denormalized_common::INTERNAL_METADATA_COLUMN;
 
 use crate::formats::decoders::avro::AvroDecoder;
 use crate::formats::decoders::json::JsonDecoder;
@@ -203,7 +204,7 @@ impl KafkaTopicBuilder {
         fields.insert(
             fields.len(),
             Arc::new(Field::new(
-                String::from("_streaming_internal_metadata"),
+                String::from(INTERNAL_METADATA_COLUMN),
                 DataType::Struct(Fields::from(struct_fields)),
                 true,
             )),

--- a/crates/core/src/datastream.rs
+++ b/crates/core/src/datastream.rs
@@ -196,8 +196,17 @@ impl DataStream {
     }
 
     /// Return the schema of DataFrame that backs the DataStream
-    pub fn schema(&self) -> &DFSchema {
-        self.df.schema()
+    pub fn schema(&self) -> DFSchema {
+        let schema = self.df.schema().clone();
+
+        // Strip out internal metadata fields from the schema
+        let qualified_fields = schema
+            .iter()
+            .map(|(qualifier, field)| (qualifier.cloned(), field.clone()))
+            .filter(|(_qualifier, field)| *field.name() != "_streaming_internal_metadata")
+            .collect::<Vec<_>>();
+
+        DFSchema::new_with_metadata(qualified_fields, schema.metadata().clone()).unwrap()
     }
 
     /// Prints the schema of the underlying dataframe

--- a/crates/core/src/datastream.rs
+++ b/crates/core/src/datastream.rs
@@ -26,6 +26,7 @@ use crate::state_backend::slatedb::get_global_slatedb;
 use denormalized_orchestrator::orchestrator::Orchestrator;
 
 use denormalized_common::error::Result;
+use denormalized_common::INTERNAL_METADATA_COLUMN;
 
 /// The primary interface for building a streaming job
 ///
@@ -203,7 +204,7 @@ impl DataStream {
         let qualified_fields = schema
             .iter()
             .map(|(qualifier, field)| (qualifier.cloned(), field.clone()))
-            .filter(|(_qualifier, field)| *field.name() != "_streaming_internal_metadata")
+            .filter(|(_qualifier, field)| *field.name() != INTERNAL_METADATA_COLUMN)
             .collect::<Vec<_>>();
 
         DFSchema::new_with_metadata(qualified_fields, schema.metadata().clone()).unwrap()

--- a/py-denormalized/python/denormalized/data_stream.py
+++ b/py-denormalized/python/denormalized/data_stream.py
@@ -47,8 +47,7 @@ class DataStream:
         Returns:
             pa.Schema: The PyArrow schema describing the structure of the data
         """
-        schema = self.ds.schema()
-        return schema.remove(schema.get_field_index("_streaming_internal_metadata"))
+        return self.ds.schema()
 
     def select(self, expr_list: list[Expr]) -> "DataStream":
         """Select specific columns or expressions from the DataStream.

--- a/py-denormalized/python/denormalized/data_stream.py
+++ b/py-denormalized/python/denormalized/data_stream.py
@@ -47,7 +47,8 @@ class DataStream:
         Returns:
             pa.Schema: The PyArrow schema describing the structure of the data
         """
-        return self.ds.schema()
+        schema = self.ds.schema()
+        return schema.remove(schema.get_field_index("_streaming_internal_metadata"))
 
     def select(self, expr_list: list[Expr]) -> "DataStream":
         """Select specific columns or expressions from the DataStream.

--- a/py-denormalized/src/datastream.rs
+++ b/py-denormalized/src/datastream.rs
@@ -13,6 +13,7 @@ use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion_python::expr::{join::PyJoinType, PyExpr};
 use tokio::task::JoinHandle;
 
+use denormalized::common::INTERNAL_METADATA_COLUMN;
 use denormalized::datastream::DataStream;
 
 use crate::errors::{py_denormalized_err, DenormalizedError, Result};
@@ -242,7 +243,7 @@ impl PyDataStream {
                             Ok(Some(batch)) => {
                                 Python::with_gil(|py| -> PyResult<()> {
                                     let mut batch = batch.clone();
-                                    if let Ok(col_idx) = batch.schema_ref().index_of("_streaming_internal_metadata") {
+                                    if let Ok(col_idx) = batch.schema_ref().index_of(INTERNAL_METADATA_COLUMN) {
                                         batch.remove_column(col_idx);
                                     }
 

--- a/py-denormalized/src/datastream.rs
+++ b/py-denormalized/src/datastream.rs
@@ -4,8 +4,7 @@ use futures::StreamExt;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::task::JoinHandle;
-
+use core::ops::Index;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::pyarrow::PyArrowType;
 use datafusion::arrow::pyarrow::ToPyArrow;
@@ -13,6 +12,7 @@ use datafusion::common::JoinType;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion_python::expr::{join::PyJoinType, PyExpr};
+use tokio::task::JoinHandle;
 
 use denormalized::datastream::DataStream;
 
@@ -242,8 +242,12 @@ impl PyDataStream {
                         match message.transpose() {
                             Ok(Some(batch)) => {
                                 Python::with_gil(|py| -> PyResult<()> {
-                                    let batch = batch.clone().to_pyarrow(py)?;
-                                    func.call1(py, (batch,))?;
+                                    let mut batch = batch.clone();
+                                    if let Ok(col_idx) = batch.schema_ref().index_of("_streaming_internal_metadata") {
+                                        batch.remove_column(col_idx);
+                                    }
+
+                                    func.call1(py, (batch.to_pyarrow(py)?,))?;
                                     Ok(())
                                 })?;
                             },

--- a/py-denormalized/src/datastream.rs
+++ b/py-denormalized/src/datastream.rs
@@ -4,7 +4,6 @@ use futures::StreamExt;
 use std::sync::Arc;
 use std::time::Duration;
 
-use core::ops::Index;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::pyarrow::PyArrowType;
 use datafusion::arrow::pyarrow::ToPyArrow;


### PR DESCRIPTION
We need to track additional metadata on RecordBatches as they move through the pipeline. This data is added in the form of additional columns. This internal data should ideally be transparent to the user and so should be stripped out automatically by the public API.

This PR:
- Automatically strips the metadata column out of the schema returned from `DataStream.schema()`
- Removes the metadata column from the recordbatch before involving a user provided python sink function